### PR TITLE
fix: Use correct commands directory

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ class DuckBot(commands.Bot):
 
     async def setup_hook(self):
         # Dynamically load all command groups from the commands directory
-        for _, module_name, _ in pkgutil.iter_modules(["commands"]):
+        for _, module_name, _ in pkgutil.iter_modules(["src/commands"]):
             module = importlib.import_module(f"commands.{module_name}")
             for attribute_name in dir(module):
                 attribute = getattr(module, attribute_name)


### PR DESCRIPTION
### Description
Fixes command groups importing.

### Changes Made
Use correct commands directory.

### Related Issues
N/A

### Additional Notes
N/A
