### PR TITLE
fix: Make lint action only check code formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,5 +22,5 @@ jobs:
           pip install poetry
           poetry install
 
-      - name: Format code with Black
-        run: poetry run black .
+      - name: Check code formatting with Black
+        run: poetry run black . --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "DuckBot is the CS Club's Discord Bot, created by the CS Club Open
 authors = ["CS Club Open Source Team <dev@csclub.org.au>"]
 license = "MIT"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
### Description
Make lint action only check code formatting with Black.

### Changes Made
Make lint action only check code formatting with Black rather than fixing it, which is pointless as it only does so within the action environment.

### Related Issues
N/A

### Additional Notes
Adding git hook for Black using pre-commit will be done in a seperate PR.
