### PR TITLE
[Fix] Fixed bug when a user with no avatar has a message sent to the skullboard 

### DIFF
--- a/src/commands/skullboard.py
+++ b/src/commands/skullboard.py
@@ -97,7 +97,7 @@ class SkullboardManager:
         guild = self.client.get_guild(message.guild.id)
         member = guild.get_member(message.author.id)
         user_nickname = member.nick if member.nick else message.author.name
-        user_avatar_url = message.author.avatar.url if message.author.avatar else ''
+        user_avatar_url = message.author.avatar.url if message.author.avatar else ""
 
         # Constructing the message content
         message_jump_url = message.jump_url

--- a/src/commands/skullboard.py
+++ b/src/commands/skullboard.py
@@ -97,7 +97,7 @@ class SkullboardManager:
         guild = self.client.get_guild(message.guild.id)
         member = guild.get_member(message.author.id)
         user_nickname = member.nick if member.nick else message.author.name
-        user_avatar_url = message.author.avatar.url
+        user_avatar_url = message.author.avatar.url if message.author.avatar else ''
 
         # Constructing the message content
         message_jump_url = message.jump_url


### PR DESCRIPTION
When a user who has no profile picture has a message sent to the skullboard, it crashes the bot (trying to access a property for a value of type None). 
Now defaults to '' URL when no profile picture is detected.
