### PR TITLE
fix: Mount db folder in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - csclub
     volumes:
-      - /home/admin/duckbot/db:/db
+      - ~/duckbot/db:/db
 
 networks:
   csclub:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - PGID=1000
     networks:
       - csclub
+    volumes:
+      - /home/admin/duckbot/db:/db
 
 networks:
   csclub:


### PR DESCRIPTION
### Description
Mount db folder in docker compose to make db persistent when docker container is recreated after code changes.

### Changes Made
Mount db folder in docker compose.

### Related Issues
N/A

### Additional Notes
N/A
