### PR TITLE
build(ci) Use Github runner

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     needs: lint-format
     name: Build
-    runs-on: [self-hosted, ARM64] # Since deployment is on arm64
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -30,11 +30,36 @@ jobs:
           role-session-name: ${{ secrets.AWS_ROLE_SESSION_NAME }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Set up QEMU for ARM64
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build Docker container
         run: |
           docker buildx build \
-            --platform=linux/arm64 --file=Dockerfile -t duckbot .
+            --platform=linux/arm64 \
+            --tag duckbot:latest \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
+            --file=Dockerfile .
           docker image save duckbot | gzip > duckbot.tar.gz
+
+      - name: Save Docker cache
+        if: success()
+        run: |
+          rsync -a --delete /tmp/.buildx-cache-new/ /tmp/.buildx-cache/
 
       - name: Copy image and compose file to S3
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM python:3.11-slim as base
+FROM python:3.11-slim AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
### Description
Use Github runner and add caching to fix the server sometimes crashing during build requiring a full instance restart.

### Changes Made
- Switched to Github amd64 runner using QEMU rather than self-hosted arm64 runner
- Add caching
- Fix FromAsCasing warning

### Related Issues
N/A

### Additional Notes
N/A
