### PR TITLE
Fix chat history deletion and change chat command prefix

### DIFF
--- a/src/commands/gemini.py
+++ b/src/commands/gemini.py
@@ -262,7 +262,7 @@ class GeminiBot:
                 len(self.chat.history) >= 50
                 or self.model.count_tokens(self.chat.history).total_tokens > 800000
             ):
-                self.chat.history([])
+                self.chat.history = []
                 delete_files()
 
         return response_embeds

--- a/src/main.py
+++ b/src/main.py
@@ -199,13 +199,13 @@ async def help(interaction: Interaction):
 @client.event
 async def on_message(message: Message):
     if (
-        client.user.mentioned_in(message) or "d." in message.clean_content
+        client.user.mentioned_in(message) or "d.chat" in message.clean_content
     ) and message.author != client.user:
         attachment = message.attachments[0] if message.attachments else None
 
         bot_response = await client.gemini_model.query(
             author=message.author.display_name,
-            message=message.clean_content.replace("d.", ""),
+            message=message.clean_content.replace("d.chat", ""),
             attachment=attachment,
         )
         await message.reply(embeds=bot_response, mention_author=False)


### PR DESCRIPTION
### Description
Fix chat history deletion and change chat command prefix

### Changes Made
- Make chat history deletion work properly
- Change the command prefix for chat to `d.chat`

### Related Issues
N/A

### Additional Notes
N/A
