### PR TITLE
feat: Help Menu Changes

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -177,7 +177,6 @@ class HelpMenu(ui.View):
         super().__init__()
         self.value = None
         self.commands = list(client.tree.get_commands(guild=Object(GUILD_ID)))
-        self.children
 
     def createMenu(self, page: int):
         if page < 0:
@@ -186,6 +185,13 @@ class HelpMenu(ui.View):
             self.currentpage = len(self.commands)-1
         else:
             self.currentpage = page
+
+        for item in self.children:
+            if isinstance(item, ui.Button):
+                if item.label == "Next":
+                    item.disabled = self.currentpage >= len(self.commands)-1
+                if item.label == "Back":
+                    item.disabled = self.currentpage == 0
         
         embed = Embed(
                 title="Invalid embed",
@@ -240,18 +246,6 @@ class HelpMenu(ui.View):
                     title=f"/{command.name}", description=command.description, color=Color.yellow(),
                 )
         return embed
-    
-    @ui.button(label="Next", style=ButtonStyle.primary)
-    async def menu_next(self, interaction: Interaction, button: ui.Button, ):
-        self.currentpage +=1
-        if self.currentpage > len(self.commands)-1:
-            return
-        elif self.currentpage > len(self.commands)-2:
-            button.disabled = True
-
-        embed = self.createMenu(self.currentpage)
-        await interaction.response.edit_message(embed = embed, view=self)
-    
     @ui.button(label="Back", style=ButtonStyle.primary)
     async def menu_back(self, interaction: Interaction, button: ui.Button, ):
         self.currentpage -=1
@@ -259,6 +253,17 @@ class HelpMenu(ui.View):
             button.disabled = True
             await interaction.response.defer()
             return
+
+        embed = self.createMenu(self.currentpage)
+        await interaction.response.edit_message(embed = embed, view=self)
+
+    @ui.button(label="Next", style=ButtonStyle.primary)
+    async def menu_next(self, interaction: Interaction, button: ui.Button, ):
+        self.currentpage +=1
+        if self.currentpage > len(self.commands)-1:
+            return
+        elif self.currentpage > len(self.commands)-2:
+            button.disabled = True
 
         embed = self.createMenu(self.currentpage)
         await interaction.response.edit_message(embed = embed, view=self)

--- a/src/main.py
+++ b/src/main.py
@@ -215,7 +215,6 @@ class HelpMenu(ui.View):
                 description="DuckBot is the CS Club's Discord bot, created by the CS Club Open Source Team.",
                 color=Color.yellow(),
             )
-
             for command in self.commands:
                 if isinstance(command, app_commands.Group):
                     # Add the group name
@@ -223,11 +222,17 @@ class HelpMenu(ui.View):
                         name=f"/{command.name}", value=f"{command.description}", inline=False
                     )
             embed.add_field(
-                name="/misc", value="Miscellaneous commands", inline=False
+                name="Misc", value="Miscellaneous commands", inline=False
             )
+            for command in self.commands:
+                if not isinstance(command, app_commands.Group):
+                    embed.add_field(
+                        name=f"/{command.name}", value=f"{command.description}", inline=False
+                    )
+                    
         elif self.currentpage > 0:
             command = self.commands[self.currentpage]
-
+                
             if isinstance(command, app_commands.Group):
                 # Add the group name
                 embed = Embed(
@@ -246,6 +251,7 @@ class HelpMenu(ui.View):
                     title=f"/{command.name}", description=command.description, color=Color.yellow(),
                 )
         return embed
+    
     @ui.button(label="Back", style=ButtonStyle.primary)
     async def menu_back(self, interaction: Interaction, button: ui.Button, ):
         self.currentpage -=1

--- a/src/main.py
+++ b/src/main.py
@@ -201,6 +201,10 @@ async def help(interaction: Interaction):
 # Ignore non-slash commands
 @client.event
 async def on_message(message: Message):
+    # Ignore DMs by checking if the message was sent in a server
+    if message.guild is None:
+        return
+
     if (
         client.user.mentioned_in(message) or "d.chat" in message.clean_content
     ) and message.author != client.user:


### PR DESCRIPTION
### Description
Changing the help command to use a menu and utilize buttons for switching to see commands. 

### Changes Made
- Created a new HelpMenu class to utilize ui.view
- Created methods CreateMenu, menu_next and menu_back to manage message embed

### Related Issues
Fixes issue#42

### Additional Notes
![image](https://github.com/user-attachments/assets/64a4ab46-08db-4d50-9f3d-7b6e45533e83)
![image](https://github.com/user-attachments/assets/58e27cbf-554d-4b11-823f-17f221b2a939)

TODO: Move class to own file
TODO: Add buttons to skip to end and start (see issue#42)
TODO: implement a selectmenu (see issue#42)
TODO: Move Misc commands into class or group
TODO: implement /commandname to pull up dedicated help menu
