### PR TITLE
fix(chat): Remove @DuckBot in response

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -195,7 +195,9 @@ async def on_message(message: Message):
         bot_response = await client.gemini_model.query(
             author_id=message.author.id,
             author=message.author.display_name,
-            message=message.content.replace("d.chat", "").replace(f"<@{client.user.id}>", "").strip(),
+            message=message.content.replace("d.chat", "")
+            .replace(f"<@{client.user.id}>", "")
+            .strip(),
             attachment=attachment,
         )
         await message.reply(embeds=bot_response, mention_author=False)

--- a/src/main.py
+++ b/src/main.py
@@ -195,7 +195,7 @@ async def on_message(message: Message):
         bot_response = await client.gemini_model.query(
             author_id=message.author.id,
             author=message.author.display_name,
-            message=message.clean_content.replace("d.chat", ""),
+            message=message.content.replace("d.chat", "").replace(f"<@{client.user.id}>", "").strip(),
             attachment=attachment,
         )
         await message.reply(embeds=bot_response, mention_author=False)


### PR DESCRIPTION
### Description
Chat command shouldn't include @DuckBot in response

### Changes Made
- Switched from `clean_content` to `content` for message processing.

### Related Issues
Fixes #75 

### Additional Notes
No significant changes in behaviour; only minor adjustments in tag handling (e.g., `@unglinh` instead of full name `@Linh Ung`.