### PR TITLE
fix: Update KNOWN_SPAM_MESSAGES_URL to include limit parameter

### DIFF
--- a/src/utils/spam_detection.py
+++ b/src/utils/spam_detection.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 LOG_CHANNEL_ID = int(os.getenv("LOG_CHANNEL_ID"))
 CMS_URL = os.getenv("CMS_URL")
-KNOWN_SPAM_MESSAGES_URL = f"{CMS_URL}/api/known-spam-messages"
+KNOWN_SPAM_MESSAGES_URL = f"{CMS_URL}/api/known-spam-messages?limit=500"
 
 
 async def fetch_spam_messages():


### PR DESCRIPTION
### Description
Update KNOWN_SPAM_MESSAGES_URL to include limit parameter to fetch all messages.

### Changes Made
Update KNOWN_SPAM_MESSAGES_URL to include limit parameter of 500 to fetch all messages.

### Related Issues
N/A

### Additional Notes
N/A
