### PR TITLE
fix(docker): Ensure database directory is writable by non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ RUN groupadd --system --gid 999 nonroot \
 # Copy the application from the builder
 COPY --from=builder --chown=nonroot:nonroot /app /app
 
-# Ensure the database directory is writable by the non-root user
-RUN chown -R nonroot:nonroot /app/db \
+# Ensure the database directory exists and is writable by the non-root user.
+RUN mkdir -p /app/db \
+ && chown -R nonroot:nonroot /app/db \
  && chmod -R 0775 /app/db
 
 # Place executables in the environment at the front of the path


### PR DESCRIPTION
### Description
Ensure database directory is writable by non-root user.

### Changes Made
Ensure database directory is writable by non-root user.

### Related Issues
N/A

### Additional Notes
N/A
