### PR TITLE
fix: Correct Renovate config datasource references 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,13 +28,13 @@
       "enabled": false
     },
     {
-      "matchDatasources": ["pip"],
+      "matchDatasources": ["pypi"],
       "matchUpdateTypes": ["security"],
-      "groupName": "pip security updates",
-      "groupSlug": "pip-security-updates"
+      "groupName": "pypi security updates",
+      "groupSlug": "pypi-security-updates"
     },
     {
-      "matchDatasources": ["pip"],
+      "matchDatasources": ["pypi"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "enabled": false
     },


### PR DESCRIPTION
### Description
Correct datasource references from 'pip' to 'pypi' in Renovate config

### Changes Made
Correct datasource references from 'pip' to 'pypi' in Renovate config

### Related Issues
N/A

### Additional Notes
N/A
